### PR TITLE
use static on inline methods to comply with C99 linkage rules

### DIFF
--- a/stringy/fastsearch.h
+++ b/stringy/fastsearch.h
@@ -18,7 +18,7 @@
 #define BLOOM_ADD(mask, ch) ((mask |= (1 << ((ch) & 0x1F))))
 #define BLOOM(mask, ch)     ((mask &  (1 << ((ch) & 0x1F))))
 
-inline size_t fastsearch(const char* string, size_t slen,
+inline static size_t fastsearch(const char* string, size_t slen,
            const char* token, size_t tlen,
            size_t maxcount, int mode) {
     // set maxcount = -1 to find all.

--- a/stringy/stringy.c
+++ b/stringy/stringy.c
@@ -18,13 +18,13 @@ Methods for fast string operations
 # define lua_rawlen lua_objlen
 #endif
 
-inline int get_start(lua_State *L, int nargs, int string_len){
+inline static int get_start(lua_State *L, int nargs, int string_len){
     int start = (nargs > 2) ? lua_tonumber(L, 3) - 1: 0;
     // what about when they pass 0?
     if(start < 0) { start = string_len + start + 1; }
     return start;
 }
-inline int get_end(lua_State *L, int nargs, int string_len){
+inline static int get_end(lua_State *L, int nargs, int string_len){
     int end = (nargs > 3) ? lua_tonumber(L, 4) - 1: string_len;
     if(end < 0) { end = string_len + end + 1; }
     return end;


### PR DESCRIPTION
Without this you may find yourself with unresolved symbols on module load.

https://github.com/brentp/lua-stringy/issues/7